### PR TITLE
[Visual Studio 2017] Fixed error CS0227

### DIFF
--- a/src/L2dotNET/L2dotNET.csproj
+++ b/src/L2dotNET/L2dotNET.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">


### PR DESCRIPTION
Fixed error CS0227: Unsafe code may only appear if compiling with /unsafe