### PR TITLE
Lazycache + ShowHtm fix

### DIFF
--- a/src/L2dotNET/Models/player/L2Player.cs
+++ b/src/L2dotNET/Models/player/L2Player.cs
@@ -205,7 +205,7 @@ namespace L2dotNET.Models.player
         {
             if (file.EndsWithIgnoreCase(".htm"))
             {
-                SendPacket(new NpcHtmlMessage(this, $"./html/ {file}", o.ObjId, 0));
+                SendPacket(new NpcHtmlMessage(this, $"./html/{file}", o.ObjId, 0));
                 L2Npc npc = o as L2Npc;
                 if (npc != null)
                     FolkNpc = npc;

--- a/src/L2dotNET/tables/HtmCache.cs
+++ b/src/L2dotNET/tables/HtmCache.cs
@@ -85,6 +85,7 @@ namespace L2dotNET.tables
             _htmCache.Add(new L2Html(Path.GetFileNameWithoutExtension(filepath), content, filepath));
         }
 
+        /// <summary>Get HTML File by Filepath based on html directory e.g. ./html/npcdefault.htm</summary>
         public string GetHtmByFilepath(string filename)
         {
             if (string.IsNullOrEmpty(filename))
@@ -99,7 +100,7 @@ namespace L2dotNET.tables
                 {
                     CacheFile(predictedFile);
                     //Try Again
-                    html = _htmCache.FirstOrDefault(x => x.Filename.EqualsIgnoreCase(filename));
+                    html = _htmCache.FirstOrDefault(x => x.Filename.EqualsIgnoreCase(Path.GetFileNameWithoutExtension(predictedFile)));
                 }
             }
             return html != null ? html.Content : string.Empty;

--- a/src/L2dotNET/tables/HtmCache.cs
+++ b/src/L2dotNET/tables/HtmCache.cs
@@ -85,7 +85,6 @@ namespace L2dotNET.tables
             _htmCache.Add(new L2Html(Path.GetFileNameWithoutExtension(filepath), content, filepath));
         }
 
-        /// <summary>Get HTML File by Filepath based on html directory e.g. ./html/npcdefault.htm</summary>
         public string GetHtmByFilepath(string filename)
         {
             if (string.IsNullOrEmpty(filename))


### PR DESCRIPTION
Fixed lazy cache looking for full path of file. htmCache stores filename without extension and was previously unable to find the neccessary htm file.

Also fixed ShowHtm which had an extra space, as a side effect of these fixes the servnews @ EnterWorld is now working. Other showHtm based methods should also be working.