### PR TITLE
More Cache Fixes + Client crash

### DIFF
--- a/src/L2dotNET/Commands/Admin/AdminChat.cs
+++ b/src/L2dotNET/Commands/Admin/AdminChat.cs
@@ -8,7 +8,7 @@ namespace L2dotNET.Commands.Admin
     {
         protected internal override void Use(L2Player admin, string alias)
         {
-            admin.ShowHtmAdmin("main.htm", false);
+            
         }
     }
 }

--- a/src/L2dotNET/Models/player/L2Player.cs
+++ b/src/L2dotNET/Models/player/L2Player.cs
@@ -668,7 +668,7 @@ namespace L2dotNET.Models.player
 
         public void ShowHtmAdmin(string val, bool plain)
         {
-            SendPacket(new TutorialShowHtml(this, val, true));
+            SendPacket(new NpcHtmlMessage(this, val, this.ObjId));
 
             ViewingAdminPage = 1;
         }

--- a/src/L2dotNET/tables/HtmCache.cs
+++ b/src/L2dotNET/tables/HtmCache.cs
@@ -38,7 +38,7 @@ namespace L2dotNET.tables
         public void Initialize()
         {
             _htmCache = new List<L2Html>();
-            _htmFiles = DirSearch("./html/");
+            _htmFiles = DirSearch("./html");
             if (!Config.Config.Instance.ServerConfig.LazyHtmlCache)
             {
                 BuildHtmCache();
@@ -108,6 +108,8 @@ namespace L2dotNET.tables
         private List<string> DirSearch(string sDir)
         {
             List<string> files = new List<string>();
+            sDir += Path.AltDirectorySeparatorChar;
+
             try
             {
                 files.AddRange(Directory.GetFiles(sDir));


### PR DESCRIPTION
Lazy cache and full cache were only working for base ./html directries. any html files deeper were being cached improperly i.e ./html/admin/main_menu.htm was actually cached as ./html/admin\main_menu.htm

As the client sends further paths as forward slashes, to reduce further processing later, sDir now is appended with the alt seperator. all files now cache properly.

Also fixed client side crash using //chat command as it was sending tutorialshowhtml which cannot have a title in th htm or it will cause crash.

For now disabled //chat as its not implemented, any testing should be done with //test