### PR TITLE
Npc Health/MP Fix + Server CPU Utilization

### DIFF
--- a/src/L2dotNET/Models/npcs/L2Monster.cs
+++ b/src/L2dotNET/Models/npcs/L2Monster.cs
@@ -14,15 +14,16 @@ namespace L2dotNET.Models.Npcs
         private readonly ILog Log = LogManager.GetLogger(typeof(L2Monster));
 
         private Timer CorpseTimer;
+        public override int MaxHp => (int)Template.Hp;
+        public override int MaxMp => (int)Template.Mp;
 
         public L2Monster(int objectId, NpcTemplate template, L2Spawn spawn) : base(objectId, template, spawn)
         {
             Template = template;
             Name = template.Name;
             InitializeCharacterStatus();
-
-            CharStatus.SetCurrentHp(Template.BaseHpMax(0));
-            CharStatus.SetCurrentMp(Template.BaseMpMax(0));
+            CharStatus.SetCurrentHp(MaxHp);
+            CharStatus.SetCurrentMp(MaxMp);
             //Stats = new CharacterStat(this);
         }
 

--- a/src/L2dotNET/templates/NpcTemplate.cs
+++ b/src/L2dotNET/templates/NpcTemplate.cs
@@ -19,6 +19,8 @@ namespace L2dotNET.Templates
         public int LHand { get; set; }
         public int EnchantEffect { get; set; }
         public int CorpseTime { get; set; }
+        public double Hp { get; set; }
+        public double Mp { get; set; }
 
         public int DropHerbGroup { get; set; }
         public Race race = Race.Unknown;
@@ -65,6 +67,8 @@ namespace L2dotNET.Templates
             LHand = set.GetInt("lHand");
             EnchantEffect = set.GetInt("enchant");
             CorpseTime = set.GetInt("corpseTime", 7);
+            Hp = set.GetDouble("hp");
+            Mp = set.GetDouble("mp");
 
             DropHerbGroup = set.GetInt("dropHerbGroup");
             //if (_dropHerbGroup > 0 && HerbDropTable.getInstance().getHerbDroplist(_dropHerbGroup) == null)


### PR DESCRIPTION
Health data of NPC's loaded and set in template.

As a side effect of this change CPU usage of the server has decreased by 80%.  Now that there are not 46,000 Regen tasks running for each L2Monster that spawned with incorrect hp values.

Ultimately CharStatus needs to know what type of character it is, as the BaseHpMax calculation is really based on players, not NPC's